### PR TITLE
Remove ArrayUtils.toMemory and references to it

### DIFF
--- a/contracts/DataExchange.sol
+++ b/contracts/DataExchange.sol
@@ -302,8 +302,7 @@ contract DataExchange is Ownable, Destructible, ModifierUtils {
       if (!isOrderVerified) {
         dest = buyer;
       }
-      buyerBalance[buyer][orderAddr][seller] =
-        buyerBalance[buyer][orderAddr][seller].sub(orderPrice);
+      buyerBalance[buyer][orderAddr][seller] = buyerBalance[buyer][orderAddr][seller].sub(orderPrice);
       token.transfer(dest, orderPrice);
 
       emit TransactionCompleted(order, seller);
@@ -341,7 +340,7 @@ contract DataExchange is Ownable, Destructible, ModifierUtils {
   function getOrdersForNotary(
     address notary
   ) public view returns (address[]) {
-    return ArrayUtils.toMemory(ordersByNotary[notary]);
+    return ordersByNotary[notary];
   }
 
   /**
@@ -352,7 +351,7 @@ contract DataExchange is Ownable, Destructible, ModifierUtils {
   function getOrdersForSeller(
     address seller
   ) public view returns (address[]) {
-    return ArrayUtils.toMemory(ordersBySeller[seller]);
+    return ordersBySeller[seller];
   }
 
   /**
@@ -363,7 +362,7 @@ contract DataExchange is Ownable, Destructible, ModifierUtils {
   function getOrdersForBuyer(
     address buyer
   ) public view returns (address[]) {
-    return ArrayUtils.toMemory(ordersByBuyer[buyer]);
+    return ordersByBuyer[buyer];
   }
 
   /**

--- a/contracts/lib/ArrayUtils.sol
+++ b/contracts/lib/ArrayUtils.sol
@@ -25,17 +25,4 @@ library ArrayUtils {
     return rs;
   }
 
-  /**
-   * @dev Converts a storage array of addresses into a memory array of addresses
-   * @param xs Storage array to convert.
-   * @return A memory array of addresses.
-   */
-  function toMemory(address[] xs) internal pure returns (address[]) {
-    address[] memory rs = new address[](xs.length);
-    for (uint i = 0; i < xs.length; i++) {
-      rs[i] = xs[i];
-    }
-    return rs;
-  }
-
 }


### PR DESCRIPTION
According to one observation made to the team:
> Second, we would like to ask what the intent of the `toMemory` function of `ArrayUtils` is.
> Upon first inspection it seems that this behavior is not really necessary,
> since the calling functions (such as `getOrdersForNotary` in `DataExchange`)
> could achieve the same results returning the address array directly.
So references to that function were removed.

Also, fixed a solium lint error (operator-whitespace) in closeDataResponse function.