### PR TITLE
Test DataExchange: closeDataResponse missing branches

### DIFF
--- a/contracts/DataExchange.sol
+++ b/contracts/DataExchange.sol
@@ -320,10 +320,10 @@ contract DataExchange is TokenDestructible, Pausable {
   ) public whenNotPaused isOrderLegit(orderAddr) returns (bool) {
     DataOrder order = DataOrder(orderAddr);
     address buyer = order.buyer();
-    address notary = order.getNotaryForSeller(seller);
-
-    require(msg.sender == buyer || msg.sender == notary);
     require(order.hasSellerBeenAccepted(seller));
+
+    address notary = order.getNotaryForSeller(seller);
+    require(msg.sender == buyer || msg.sender == notary);
     require(
       CryptoUtils.isNotaryVeredictValid(
         orderAddr,


### PR DESCRIPTION
Se agregan tests para los siguientes branches:
- [x] closeDataResponse: 
<img src="https://user-images.githubusercontent.com/5324858/41755639-b84e8e8e-75ae-11e8-94d9-f882f6ca44ff.png" width="300" />

Además, se reordenan los examples para seguir el mismo orden en el que ocurren las validaciones en el contrato.

En otro PR agrego tests para los casos de `payPlayers`