### PR TITLE
Improve notary url update logging

### DIFF
--- a/contracts/DataExchange.sol
+++ b/contracts/DataExchange.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 
 contract DataExchange {
   event NotaryRegistered(address indexed notary);
-  event NotaryUpdated(address indexed notary);
+  event NotaryUpdated(address indexed notary, string oldNotaryUrl);
   event NotaryUnregistered(address indexed notary);
   event DataOrderCreated(uint256 indexed orderId, address indexed buyer);
   event DataOrderClosed(uint256 indexed orderId, address indexed buyer);
@@ -24,17 +24,20 @@ contract DataExchange {
 
   /**
    * @notice Registers sender as a notary or updates an already existing one.
-   * @param notaryUrl Public URL of the notary where the notary info can be obtained.
+   * @param newNotaryUrl Public URL of the notary where the notary info can be obtained.
    * @return true if the notary was successfully registered or updated, reverts otherwise.
    */
   function registerNotary(
-    string notaryUrl
+    string newNotaryUrl
   ) public returns (bool) {
-    require(isNotEmpty(notaryUrl), "notaryUrl must not be empty");
+    require(isNotEmpty(newNotaryUrl), "newNotaryUrl must not be empty");
     bool isUpdate = isSenderNotary();
-    notaryUrls[msg.sender] = notaryUrl;
+
+    string memory oldNotaryUrl = notaryUrls[msg.sender];
+    notaryUrls[msg.sender] = newNotaryUrl;
+
     if (isUpdate) {
-      emit NotaryUpdated(msg.sender);
+      emit NotaryUpdated(msg.sender, oldNotaryUrl);
     } else {
       emit NotaryRegistered(msg.sender);
     }

--- a/contracts/DataExchange.sol
+++ b/contracts/DataExchange.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 
 contract DataExchange {
   event NotaryRegistered(address indexed notary);
-  event NotaryUpdated(address indexed notary, string oldNotaryUrl);
+  event NotaryUpdated(address indexed notary, string oldNotaryUrl, string newNotaryUrl);
   event NotaryUnregistered(address indexed notary);
   event DataOrderCreated(uint256 indexed orderId, address indexed buyer);
   event DataOrderClosed(uint256 indexed orderId, address indexed buyer);
@@ -37,7 +37,7 @@ contract DataExchange {
     notaryUrls[msg.sender] = newNotaryUrl;
 
     if (isUpdate) {
-      emit NotaryUpdated(msg.sender, oldNotaryUrl);
+      emit NotaryUpdated(msg.sender, oldNotaryUrl, newNotaryUrl);
     } else {
       emit NotaryRegistered(msg.sender);
     }


### PR DESCRIPTION
The event `NotaryUpdated` of the `registerNotary` function now logs both old and new public notary URLs. This will allow off-chain clients to easily track the history of notary's public URL.

Note that neither of the two new event parameters are indexed. Is there a reason why they should be indexed?